### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,15 @@ else
 	data_home := ${XDG_DATA_HOME}
 endif
 
+PREFIX := /usr/local
+
+install_dir = $(DESTDIR)/$(PREFIX)/share/steam/compatibilitytools.d/$(tool_dir)
+
 dev_install_dir = $(data_home)/Steam/compatibilitytools.d/$(tool_dir_dev)
 
+.PHONY: all
+
+all: release
 
 build:
 	cargo build
@@ -73,6 +80,10 @@ $(tool_dir): \
 
 $(tool_dir).tar.xz: $(tool_dir)
 	tar -cJf $@ $(tool_dir)
+
+install: $(tool_dir)
+	mkdir -p $(install_dir)
+	cp -av $(tool_dir)/* $(install_dir)/
 
 user-install: \
 		build \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean doc user-install user-uninstall
+.PHONY: all build test clean doc install user-install user-uninstall
 
 # These variables are used to generate compatibilitytool.vdf:
 #
@@ -32,8 +32,6 @@ PREFIX := /usr/local
 install_dir = $(DESTDIR)/$(PREFIX)/share/steam/compatibilitytools.d/$(tool_dir)
 
 dev_install_dir = $(data_home)/Steam/compatibilitytools.d/$(tool_dir_dev)
-
-.PHONY: all
 
 all: release
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ else
 	data_home := ${XDG_DATA_HOME}
 endif
 
+STRIP := strip
+
 PREFIX := /usr/local
 
 install_dir = $(DESTDIR)/$(PREFIX)/share/steam/compatibilitytools.d/$(tool_dir)
@@ -76,9 +78,9 @@ $(tool_dir): \
 		target/release/README.md
 	mkdir -p $(tool_dir)
 	cd target/release && cp --reflink=auto -t ../../$(tool_dir) $(files)
-	strip luxtorpeda/luxtorpeda
 
 $(tool_dir).tar.xz: $(tool_dir)
+	$(STRIP) luxtorpeda/luxtorpeda
 	tar -cJf $@ $(tool_dir)
 
 install: $(tool_dir)

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ $(tool_dir): \
 		target/release/README.md
 	mkdir -p $(tool_dir)
 	cd target/release && cp --reflink=auto -t ../../$(tool_dir) $(files)
+	$(STRIP) luxtorpeda/luxtorpeda
 
 $(tool_dir).tar.xz: $(tool_dir)
-	$(STRIP) luxtorpeda/luxtorpeda
 	tar -cJf $@ $(tool_dir)
 
 install: $(tool_dir)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ test:
 
 clean:
 	cargo clean
+	rm -rf $(tool_dir)
+	rm -f $(tool_dir).tar.xz
 
 doc:
 	cargo doc --document-private-items --open
@@ -58,7 +60,7 @@ target/debug/%: %
 target/release/%: %
 	cp --reflink=auto $< $@
 
-$(tool_dir).tar.xz: \
+$(tool_dir): \
 		release \
 		target/release/compatibilitytool.vdf \
 		target/release/toolmanifest.vdf \
@@ -68,8 +70,9 @@ $(tool_dir).tar.xz: \
 	mkdir -p $(tool_dir)
 	cd target/release && cp --reflink=auto -t ../../$(tool_dir) $(files)
 	strip luxtorpeda/luxtorpeda
+
+$(tool_dir).tar.xz: $(tool_dir)
 	tar -cJf $@ $(tool_dir)
-	rm -rf $(tool_dir)
 
 user-install: \
 		build \


### PR DESCRIPTION
This is an attempt to make the makefile more compatible with common package-building workflows, e.g. installable via `make && make install`.
Tested with flatpak-builder (obviously), should also work with at least rpmbuild.