### PR TITLE
Luxtorpeda DOES require one dependency when building from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ additional dependencies.
 
 ## Installation (debug build, from source)
 
-0. Download the latest version of Rust: https://www.rust-lang.org/.
+0. Download the latest version of Rust: https://www.rust-lang.org/ and verify that openssl is installed on your system.
+
+Debian, Ubuntu et consortes
+
+       $ sudo apt install libssl-dev
+       
+Fedora 
+
+       $ sudo dnf install openssl-devel
+       
 1. Close Steam.
 2. Clone the repository, then use makefile to trigger `cargo build` and install:
 


### PR DESCRIPTION
I´ve had to install libssl-dev due to that.

To be fair, I´m using deepin 15.11, which has it´s own debian repo, but is usually more outdated, so it this might be preinstalled on more ¨updated¨ distros like those.
I wasn´t sure if the package name was the exact one on OpenSUSE and Manjaro/Arch so i didn´t added those.

If this sound more of an issue, I´ll open one for it if needed.