### PR TITLE
Added UT 2004 (Official Binaries) - Issue With Luxtorpeda Finding Paths?

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You need to select Luxtorpeda as a compatibility tool first, of course.
 | [Heretic: Shadow of the Serpent Riders](https://store.steampowered.com/app/2390/) | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Hexen: Beyond Heretic](https://store.steampowered.com/app/2360/)                 | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Doki Doki Literature Club!](https://store.steampowered.com/app/698780/)          | [Ren'Py](https://www.renpy.org/)                            |                     | **(Free to play)** *Using Linux version bundled with Windows version*
-| [Unreal Tournament 2004](https://store.steampowered.com/app/13230/Unreal_Tournament_2004_Editors_Choice_Edition/)                 | [Original Port](https://github.com/dreamer/luxtorpeda/issues/45#issuecomment-539770152)           
+| [Unreal Tournament 2004](https://store.steampowered.com/app/13230/Unreal_Tournament_2004_Editors_Choice_Edition/)                 | [Original Port](https://github.com/dreamer/luxtorpeda/issues/45#issuecomment-539770152)   | | Need libstdc++.so.5 installed. Will ask for CD Key (available in the steam client).  
 
 Want a specific game? Maybe we are
 [already working on it](https://github.com/dreamer/luxtorpeda/wiki/Game-engines#on-agenda-wip-and-supported-engines).

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You need to select Luxtorpeda as a compatibility tool first, of course.
 | [Heretic: Shadow of the Serpent Riders](https://store.steampowered.com/app/2390/) | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Hexen: Beyond Heretic](https://store.steampowered.com/app/2360/)                 | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Doki Doki Literature Club!](https://store.steampowered.com/app/698780/)          | [Ren'Py](https://www.renpy.org/)                            |                     | **(Free to play)** *Using Linux version bundled with Windows version*
+| [Unreal Tournament 2004](https://store.steampowered.com/app/13230/Unreal_Tournament_2004_Editors_Choice_Edition/)                 | [Original Port](https://github.com/dreamer/luxtorpeda/issues/45#issuecomment-539770152)           
 
 Want a specific game? Maybe we are
 [already working on it](https://github.com/dreamer/luxtorpeda/wiki/Game-engines#on-agenda-wip-and-supported-engines).

--- a/packages.json
+++ b/packages.json
@@ -279,5 +279,16 @@
     "698780": {
         "game_name": "Doki Doki Literature Club",
         "command": "./DDLC.sh"
+    },
+    "13230": {
+        "game_name": "UT2004",
+        "download": [
+            {
+                "name": "UT2004",
+                "url":  "https://d10sfan.gitlab.io/luxtorpeda-ut2004/",
+                "file": "ut2004-13230.tar.xz"
+            }
+        ],
+        "command": "./run-ut2004.sh"
     }
 }


### PR DESCRIPTION
Related to #45 

It looks like the Steam version includes the megapack maps, so that makes things a bit easier. I have a package (https://gitlab.com/d10sfan/luxtorpeda-ut2004) that looks to work well from a clean steam install. There is an issue with seemingly luxtorpeda finding the right working directory, which I've expanded on below.

It'll ask you with Zenity for your cd key and then writes that and does symlinks to a new directory, so the original Windows data files don't get messed with. Then, it'll do a few symlinks for some libraries, and launch the game. The first time load can take a while when it gets things ready, but after that it loads very quickly.

It uses sdlcl for sdl 1.2 support, which is included. For now, it will check if libstdc++.so.5 is installed on the user's system, and if not, it will prompt with a Zenity error. It will also check for openal, which it'll link to the proper place. If both are installed and the cd key is entered properly, it should then run without any extra user input, I figure in the future we could package libstdc++.so.5 in some way along with the rest.

Also, with the way it works, if you want to install mods, you'd want to put them in the linuxdata directory (such as linuxdata/System). There's two mods I used that worked nicely just to make it feel better on larger screen resolutions: https://forums.epicgames.com/unreal-tournament-2003-2004/user-maps-mods/beta-releases/288070-hud-scaling-fix-rc3 & https://steamcommunity.com/app/13230/discussions/0/611702631218438023/

Something I noticed that seems specific to this one:

When I launch a game through Steam for the tool (like with Arx or Quake 2), normally it's able to find the working directory correctly. With this game, it tries to load the working directory as the steam directory (~/.steam/steam). I was able to work around it by placing a shell script in that directory that only changed directories to the actual path of the game and executed the script.

My packages.json entry looks like the following (with the workaround):

```
 "13230": {
        "game_name": "UT2004",
        "package": "dist.tar.xz",
        "command": "./ut2004route.sh"
}
```

Normally it'd look like this:
```
 "13230": {
        "game_name": "UT2004",
        "package": "dist.tar.xz",
        "command": "./run-ut2004.sh"
}
```**