### PR TITLE
Add Prey 2006 - Official Binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You need to select Luxtorpeda as a compatibility tool first, of course.
 | [Heretic: Shadow of the Serpent Riders](https://store.steampowered.com/app/2390/) | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Hexen: Beyond Heretic](https://store.steampowered.com/app/2360/)                 | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Doki Doki Literature Club!](https://store.steampowered.com/app/698780/)          | [Ren'Py](https://www.renpy.org/)                            |                     | **(Free to play)** *Using Linux version bundled with Windows version*
+| [Prey (2006)](https://steamcommunity.com/app/3970)          | [Original Port](https://icculus.org/prey/)                            |                     | CD Key from Steam might be truncated. Configuration updates that may be helpful: https://steamcommunity.com/sharedfiles/filedetails/?id=1275016430
 
 Want a specific game? Maybe we are
 [already working on it](https://github.com/dreamer/luxtorpeda/wiki/Game-engines#on-agenda-wip-and-supported-engines).

--- a/packages.json
+++ b/packages.json
@@ -279,5 +279,16 @@
     "698780": {
         "game_name": "Doki Doki Literature Club",
         "command": "./DDLC.sh"
+    },
+    "3970": {
+        "game_name": "Prey 2006",
+        "download": [
+            {
+                "name": "Prey",
+                "url":  "https://d10sfan.gitlab.io/luxtorpeda-prey2006/",
+                "file": "prey2006-3970.tar.xz"
+            }
+        ],
+        "command": "./run-prey.sh"
     }
 }


### PR DESCRIPTION
This adds Prey 2006 (using the official binaries): https://gitlab.com/d10sfan/luxtorpeda-prey2006. SDLCL is used for this one as well.

There's a problem, possibly due to this game being 32 bit, where it will load fine through the command line but through luxtorpeda it'll freeze on the loading screen. I created another compatibility tool, just a simple shell script that went to the proper directory of the game and execute the run shell script, and that worked fine, so it seems to be something related to the luxtorpeda integration.

Something strange related to the CD Key was in steam the cd key seemed to have the last two numbers chopped off. I was able to get it from the original key, but something to look out for.

Also, this was a nice guide to get the game to work nicely with my ultrawide screen: https://steamcommunity.com/sharedfiles/filedetails/?id=1275016430