### PR TITLE
Add Gothic 2 using OpenGothic

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You need to select Luxtorpeda as a compatibility tool first, of course.
 | [Heretic: Shadow of the Serpent Riders](https://store.steampowered.com/app/2390/) | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Hexen: Beyond Heretic](https://store.steampowered.com/app/2360/)                 | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Doki Doki Literature Club!](https://store.steampowered.com/app/698780/)          | [Ren'Py](https://www.renpy.org/)                            |                     | **(Free to play)** *Using Linux version bundled with Windows version*
-| [Gothic 2: Gold Edition](https://store.steampowered.com/app/39510/Gothic_II_Gold_Edition/)          | [OpenGothic](https://github.com/Try/OpenGothic)                            |       `latest master`              | Steam Overlay does not work
+| [Gothic 2: Gold Edition](https://store.steampowered.com/app/39510/Gothic_II_Gold_Edition/)          | [OpenGothic](https://github.com/Try/OpenGothic)                            |       `latest master`              | Steam Overlay does not work. Engine is still in progress so not all features may be implemented.
 
 Want a specific game? Maybe we are
 [already working on it](https://github.com/dreamer/luxtorpeda/wiki/Game-engines#on-agenda-wip-and-supported-engines).

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You need to select Luxtorpeda as a compatibility tool first, of course.
 | [Heretic: Shadow of the Serpent Riders](https://store.steampowered.com/app/2390/) | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Hexen: Beyond Heretic](https://store.steampowered.com/app/2360/)                 | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Doki Doki Literature Club!](https://store.steampowered.com/app/698780/)          | [Ren'Py](https://www.renpy.org/)                            |                     | **(Free to play)** *Using Linux version bundled with Windows version*
+| [Gothic 2: Gold Edition](https://store.steampowered.com/app/39510/Gothic_II_Gold_Edition/)          | [OpenGothic](https://github.com/Try/OpenGothic)                            |       `latest master`              | Steam Overlay does not work
 
 Want a specific game? Maybe we are
 [already working on it](https://github.com/dreamer/luxtorpeda/wiki/Game-engines#on-agenda-wip-and-supported-engines).

--- a/packages.json
+++ b/packages.json
@@ -276,6 +276,17 @@
         ],
         "command": "./openmw.sh"
     },
+    "39510": {
+        "game_name": "Gothic II",
+        "download": [
+            {
+                "name": "opengothic",
+                "url":  "https://d10sfan.gitlab.io/luxtorpeda-opengothic/",
+                "file": "opengothic-39510.tar.xz"
+            }
+        ],
+        "command": "./run-gothic2.sh"
+    },
     "698780": {
         "game_name": "Doki Doki Literature Club",
         "command": "./DDLC.sh"


### PR DESCRIPTION
This uses the OpenGothic project to add support for Gothic II. There were a few Linux-specific issues with the X11 renderer that I helped fix, and it seems to work pretty well now. The engine is still in-progress but so far it seems like basic game-play is very usable, them stating at least the first chapter is mostly playable.

So far, the only thing I've seen that are issues related directly to the engine are:
* Steam overlay does not work from Luxtorpeda, but launching the game from Steam works fine. It looks like steam has the overlay disabled for this game, so there might not be any way around that.

The engine package is at https://gitlab.com/d10sfan/luxtorpeda-opengothic