### PR TITLE
Add Doom 3 BFG

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You need to select Luxtorpeda as a compatibility tool first, of course.
 | [Heretic: Shadow of the Serpent Riders](https://store.steampowered.com/app/2390/) | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Hexen: Beyond Heretic](https://store.steampowered.com/app/2360/)                 | [GZDoom](https://zdoom.org/)                                | `4.2.1`             | *Vulkan renderer crashes on exit*
 | [Doki Doki Literature Club!](https://store.steampowered.com/app/698780/)          | [Ren'Py](https://www.renpy.org/)                            |                     | **(Free to play)** *Using Linux version bundled with Windows version*
+| [Doom 3: BFG Edition](https://store.steampowered.com/app/208200/Doom_3_BFG_Edition/)          | [RBDOOM-3-BFG](https://github.com/RobertBeckebans/RBDOOM-3-BFG)                            |   `7eddea5 (from master)`                 | 
 
 Want a specific game? Maybe we are
 [already working on it](https://github.com/dreamer/luxtorpeda/wiki/Game-engines#on-agenda-wip-and-supported-engines).

--- a/packages.json
+++ b/packages.json
@@ -276,6 +276,17 @@
         ],
         "command": "./openmw.sh"
     },
+    "208200": {
+        "game_name": "Doom 3 BFG",
+        "download": [
+            {
+                "name": "doom3bfg",
+                "url":  "https://d10sfan.gitlab.io/luxtorpeda-doom3bfg/",
+                "file": "doom3bfg-208200.tar.xz"
+            }
+        ],
+        "command": "./RBDoom3BFG"
+    },
     "698780": {
         "game_name": "Doki Doki Literature Club",
         "command": "./DDLC.sh"


### PR DESCRIPTION
This adds Doom 3 BFG, using the RBDOOM-3-BFG project.

One thing noticed from the engine itself is that HDR can be a bit broken (mainly with the flashlight). Running this command (https://github.com/RobertBeckebans/RBDOOM-3-BFG/issues/290#issuecomment-176123696) while inside the game will fix it (and it'll save afterwards): ```toggle r_usehdr; reloadshaders```

The package project is at: https://gitlab.com/d10sfan/luxtorpeda-doom3bfg